### PR TITLE
Use GIS-only Drive client bootstrap

### DIFF
--- a/app.js
+++ b/app.js
@@ -244,12 +244,10 @@ async function initGoogleClient(config) {
   const [gapi] = await Promise.all([loadGoogleApiScript(), loadGoogleIdentityScript()]);
   if (!gapi) throw new Error("Google API unavailable");
   await new Promise((resolve, reject) => {
-    gapi.load("client:auth2", async () => {
+    gapi.load("client", async () => {
       try {
         await gapi.client.init({
           apiKey: config.apiKey,
-          clientId: config.clientId,
-          scope: DRIVE_SCOPE,
           discoveryDocs: DRIVE_DISCOVERY_DOCS
         });
         resolve();

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -215,12 +215,10 @@ async function initGoogleClient(config) {
   const [gapi] = await Promise.all([loadGoogleApiScript(), loadGoogleIdentityScript()]);
   if (!gapi) throw new Error("Google API unavailable");
   await new Promise((resolve, reject) => {
-    gapi.load("client:auth2", async () => {
+    gapi.load("client", async () => {
       try {
         await gapi.client.init({
           apiKey: config.apiKey,
-          clientId: config.clientId,
-          scope: DRIVE_SCOPE,
           discoveryDocs: DRIVE_DISCOVERY_DOCS,
         });
         resolve();


### PR DESCRIPTION
## Summary
- update the Drive bootstrap to load the Google API client without the deprecated auth2 module
- rebuild the compiled bundle so the deployed app uses the GIS token flow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d67f6cb96883309e9f718e8ad8ebcc