### PR TITLE
Handle disabled Google Drive API errors gracefully

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -117,6 +117,68 @@ const DRIVE_FILE_NAME = "regula-sync.json";
 const DRIVE_MIME_TYPE = "application/json";
 const DRIVE_SYNC_DEBOUNCE_MS = 2000;
 
+function extractGoogleApiErrorDetails(error) {
+  if (!error) return null;
+  const resultError = error?.result?.error;
+  const details = Array.isArray(resultError?.details) ? resultError.details : [];
+  const nestedReasons = details
+    .map((detail) => detail?.reason || detail?.metadata?.reason)
+    .filter(Boolean)
+    .map((reason) => String(reason).toLowerCase());
+  const legacyErrors = Array.isArray(resultError?.errors) ? resultError.errors : [];
+  const legacyReasons = legacyErrors
+    .map((item) => item?.reason)
+    .filter(Boolean)
+    .map((reason) => String(reason).toLowerCase());
+  const reasons = [...legacyReasons, ...nestedReasons];
+  const message =
+    resultError?.message || error?.message || error?.statusText || (typeof error === "string" ? error : "");
+  const code = resultError?.code ?? error?.code ?? error?.status ?? null;
+  const status = resultError?.status ?? error?.status ?? null;
+  return { code, status, message, reasons };
+}
+
+function maybeWrapDriveApiDisabledError(error) {
+  const details = extractGoogleApiErrorDetails(error);
+  if (!details) return null;
+  const code = Number(details.code);
+  const normalizedMessage = String(details.message || "").toLowerCase();
+  const hasDisabledReason = (details.reasons || []).some((reason) =>
+    ["accessnotconfigured", "servicedisabled", "apihasnotbeenused"].includes(reason),
+  );
+  if (
+    code === 403 &&
+    (hasDisabledReason || normalizedMessage.includes("google drive api has not been used") ||
+      normalizedMessage.includes("enable it by visiting"))
+  ) {
+    const friendly = new Error(
+      "Google Drive sync isn't available because the Google Drive API is disabled for this Regula installation. Ask the site administrator to enable the Drive API for the connected Google Cloud project, then try again.",
+    );
+    friendly.code = "drive_api_disabled";
+    friendly.cause = error;
+    friendly.details = details;
+    return friendly;
+  }
+  return null;
+}
+
+function normalizeDriveApiError(error) {
+  const wrapped = maybeWrapDriveApiDisabledError(error);
+  if (wrapped) return wrapped;
+  if (error instanceof Error) return error;
+  if (typeof error === "string") return new Error(error);
+  const fallback = new Error(error?.message || error?.statusText || "Drive request failed");
+  fallback.cause = error;
+  return fallback;
+}
+
+function buildDriveErrorNotificationMessage(error, prefix) {
+  if (!error) return prefix;
+  if (error.code === "drive_api_disabled") return error.message;
+  const detail = error?.message || String(error);
+  return `${prefix}: ${detail}`;
+}
+
 function stableStringify(value) {
   const seen = new WeakSet();
   const walk = (input) => {
@@ -1718,47 +1780,56 @@ function useDriveSync({
     if (!gapi) throw new Error("Google API not ready");
     const fileName = config.fileName || DRIVE_FILE_NAME;
     const escaped = fileName.replace(/'/g, "\\'");
-    const listResponse = await gapi.client.drive.files.list({
-      spaces: "appDataFolder",
-      fields: "files(id,name,modifiedTime)",
-      pageSize: 1,
-      q: `name='${escaped}' and trashed = false`,
-    });
-    const files = (listResponse.result && listResponse.result.files) || [];
-    if (files.length > 0 && files[0]?.id) {
-      fileIdRef.current = files[0].id;
-      return fileIdRef.current;
+    try {
+      const listResponse = await gapi.client.drive.files.list({
+        spaces: "appDataFolder",
+        fields: "files(id,name,modifiedTime)",
+        pageSize: 1,
+        q: `name='${escaped}' and trashed = false`,
+      });
+      const files = (listResponse.result && listResponse.result.files) || [];
+      if (files.length > 0 && files[0]?.id) {
+        fileIdRef.current = files[0].id;
+        return fileIdRef.current;
+      }
+      const createResponse = await gapi.client.drive.files.create({
+        fields: "id",
+        resource: {
+          name: fileName,
+          parents: ["appDataFolder"],
+          mimeType: DRIVE_MIME_TYPE,
+        },
+        media: {
+          mimeType: DRIVE_MIME_TYPE,
+          body: JSON.stringify({ version: 1 }),
+        },
+      });
+      const newId = createResponse.result?.id;
+      if (!newId) throw new Error("Failed to create Drive file");
+      fileIdRef.current = newId;
+      return newId;
+    } catch (error) {
+      throw normalizeDriveApiError(error);
     }
-    const createResponse = await gapi.client.drive.files.create({
-      fields: "id",
-      resource: {
-        name: fileName,
-        parents: ["appDataFolder"],
-        mimeType: DRIVE_MIME_TYPE,
-      },
-      media: {
-        mimeType: DRIVE_MIME_TYPE,
-        body: JSON.stringify({ version: 1 }),
-      },
-    });
-    const newId = createResponse.result?.id;
-    if (!newId) throw new Error("Failed to create Drive file");
-    fileIdRef.current = newId;
-    return newId;
   }, [config]);
 
   const downloadSnapshot = useCallback(async () => {
     const gapi = gapiRef.current;
     if (!gapi) throw new Error("Google API not ready");
     const fileId = await ensureFileId();
-    const response = await gapi.client.drive.files.get({ fileId, alt: "media" });
-    const body = typeof response.body === "string" ? response.body : response.result ? JSON.stringify(response.result) : "";
-    if (!body) return null;
     try {
-      return JSON.parse(body);
+      const response = await gapi.client.drive.files.get({ fileId, alt: "media" });
+      const body =
+        typeof response.body === "string" ? response.body : response.result ? JSON.stringify(response.result) : "";
+      if (!body) return null;
+      try {
+        return JSON.parse(body);
+      } catch (error) {
+        console.warn("Failed to parse Drive snapshot", error);
+        return null;
+      }
     } catch (error) {
-      console.warn("Failed to parse Drive snapshot", error);
-      return null;
+      throw normalizeDriveApiError(error);
     }
   }, [ensureFileId]);
 
@@ -1767,13 +1838,17 @@ function useDriveSync({
       const gapi = gapiRef.current;
       if (!gapi) throw new Error("Google API not ready");
       const fileId = await ensureFileId();
-      await gapi.client.request({
-        path: `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
-        method: "PATCH",
-        params: { uploadType: "media" },
-        headers: { "Content-Type": DRIVE_MIME_TYPE },
-        body: JSON.stringify(payload),
-      });
+      try {
+        await gapi.client.request({
+          path: `/upload/drive/v3/files/${encodeURIComponent(fileId)}`,
+          method: "PATCH",
+          params: { uploadType: "media" },
+          headers: { "Content-Type": DRIVE_MIME_TYPE },
+          body: JSON.stringify(payload),
+        });
+      } catch (error) {
+        throw normalizeDriveApiError(error);
+      }
     },
     [ensureFileId],
   );
@@ -1825,10 +1900,17 @@ function useDriveSync({
         setDriveState((prev) => ({ ...prev, syncing: false, lastSync: timestamp }));
         return snapshot;
       } catch (error) {
+        const normalizedError = normalizeDriveApiError(error);
         console.error("Drive download failed", error);
-        setDriveState((prev) => ({ ...prev, syncing: false, error }));
+        if (normalizedError !== error) {
+          console.error("Drive download failed (normalized)", normalizedError);
+        }
+        setDriveState((prev) => ({ ...prev, syncing: false, error: normalizedError }));
         if (!silent) {
-          notify?.({ type: "error", message: `Drive download failed: ${error?.message || error}` });
+          notify?.({
+            type: "error",
+            message: buildDriveErrorNotificationMessage(normalizedError, "Drive download failed"),
+          });
         }
         return null;
       }
@@ -1972,12 +2054,19 @@ function useDriveSync({
         }
         return { ok: true };
       } catch (error) {
+        const normalizedError = normalizeDriveApiError(error);
         console.error("Drive sync failed", error);
-        setDriveState((prev) => ({ ...prev, syncing: false, error }));
-        if (!silent) {
-          notify?.({ type: "error", message: `Drive sync failed: ${error?.message || error}` });
+        if (normalizedError !== error) {
+          console.error("Drive sync failed (normalized)", normalizedError);
         }
-        return { ok: false, error };
+        setDriveState((prev) => ({ ...prev, syncing: false, error: normalizedError }));
+        if (!silent) {
+          notify?.({
+            type: "error",
+            message: buildDriveErrorNotificationMessage(normalizedError, "Drive sync failed"),
+          });
+        }
+        return { ok: false, error: normalizedError };
       }
     },
     [computePayload, config, driveState.signedIn, handleSignedOut, isTokenAuthError, notify, ready, requestAccessToken, setDriveState, uploadSnapshot],


### PR DESCRIPTION
## Summary
- add helpers to detect Google Drive API disabled responses and surface clearer guidance to users
- normalize Drive API errors before updating sync state and notifications
- wrap Drive file operations with the new error handling and rebuild the compiled bundle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6858c54488330ba2895333dc605b9