### PR TITLE
Clarify Drive sync disabled messaging

### DIFF
--- a/app.js
+++ b/app.js
@@ -2290,7 +2290,7 @@ function App() {
     disabled: !driveSync.signedIn || driveSync.status !== "ready" || driveSync.syncing
   }, driveSync.syncing ? "Syncing…" : "Sync now")) : /*#__PURE__*/React.createElement("span", {
     className: "hidden text-xs sm:inline"
-  }, driveSync.status === "disabled" && driveSync.disabledReason === "drive_api_disabled" ? "Drive sync disabled by administrator" : "Drive sync not configured"), /*#__PURE__*/React.createElement("button", {
+  }, driveSync.status === "disabled" && driveSync.disabledReason === "drive_api_disabled" ? DRIVE_DISABLED_MESSAGE : "Drive sync not configured"), /*#__PURE__*/React.createElement("button", {
     className: "btn",
     onClick: () => setTheme(theme === "dark" ? "light" : "dark"),
     title: "Toggle theme"


### PR DESCRIPTION
## Summary
- show the full DRIVE_DISABLED_MESSAGE when Drive sync is disabled by the administrator so the banner matches notifications
- remove duplicate Drive error helper definitions that were causing Babel to emit a redeclaration error during the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d68b4e121c8330ba5d75813e342d3e