### PR TITLE
Handle Google Drive OAuth redirect mode

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -119,6 +119,39 @@ const DRIVE_SYNC_DEBOUNCE_MS = 2000;
 const DRIVE_DISABLED_MESSAGE =
   "Google Drive sync isn't available on this Regula site. This static installation only uses Google OAuth without the Drive API, so your data will stay on this device.";
 
+function cleanupGoogleOAuthRedirectArtifacts() {
+  if (typeof window === "undefined") return;
+  try {
+    const currentUrl = new URL(window.location.href);
+    const params = currentUrl.searchParams;
+    let searchChanged = false;
+    if (params.has("g_state")) {
+      params.delete("g_state");
+      searchChanged = true;
+    }
+    const rawHash = currentUrl.hash?.replace(/^#/, "") || "";
+    const hashParams = new URLSearchParams(rawHash);
+    const oauthKeys = ["access_token", "token_type", "expires_in", "scope", "state", "authuser", "prompt"];
+    const hasOauthHash = oauthKeys.some((key) => hashParams.has(key));
+    let hashChanged = false;
+    if (hasOauthHash) {
+      oauthKeys.forEach((key) => {
+        if (hashParams.has(key)) {
+          hashParams.delete(key);
+          hashChanged = true;
+        }
+      });
+    }
+    if (!searchChanged && !hashChanged) return;
+    const nextSearch = params.toString();
+    const nextHash = hashParams.toString();
+    const nextUrl = `${currentUrl.pathname}${nextSearch ? `?${nextSearch}` : ""}${nextHash ? `#${nextHash}` : ""}`;
+    window.history.replaceState({}, document.title, nextUrl);
+  } catch (error) {
+    console.warn("Failed to clean up Google OAuth redirect artifacts", error);
+  }
+}
+
 function extractGoogleApiErrorDetails(error) {
   if (!error) return null;
   const resultError = error?.result?.error;
@@ -205,6 +238,21 @@ function stableStringify(value) {
   }
 }
 
+function isCrossOriginIsolationEnabled() {
+  if (typeof window === "undefined") return false;
+  if (typeof window.crossOriginIsolated === "boolean") {
+    return window.crossOriginIsolated;
+  }
+  try {
+    const hasSharedArrayBuffer = typeof window.SharedArrayBuffer === "function";
+    const hasPostMessageTransfer = typeof window.postMessage === "function" && !!window.postMessage.length;
+    return hasSharedArrayBuffer && hasPostMessageTransfer;
+  } catch (error) {
+    console.warn("Failed to detect cross-origin isolation", error);
+    return false;
+  }
+}
+
 function resolveDriveConfig() {
   if (typeof window === "undefined") return null;
   const clientId =
@@ -212,7 +260,18 @@ function resolveDriveConfig() {
   if (!clientId) return null;
   const apiKey = window.GOOGLE_DRIVE_API_KEY || window.GOOGLE_API_KEY || window.__GOOGLE_API_KEY__ || "";
   const fileName = window.GOOGLE_DRIVE_FILE_NAME || DRIVE_FILE_NAME;
-  return { clientId, apiKey, fileName };
+  const configuredUxMode = (window.GOOGLE_DRIVE_UX_MODE || window.GOOGLE_OAUTH_UX_MODE || "").toLowerCase();
+  let uxMode = configuredUxMode;
+  if (!uxMode || !["popup", "redirect"].includes(uxMode)) {
+    uxMode = isCrossOriginIsolationEnabled() ? "redirect" : "popup";
+  }
+  const defaultRedirectUri = (() => {
+    if (typeof window === "undefined") return "";
+    const { origin, pathname } = window.location;
+    return `${origin}${pathname}`;
+  })();
+  const redirectUri = window.GOOGLE_DRIVE_REDIRECT_URI || window.GOOGLE_OAUTH_REDIRECT_URI || defaultRedirectUri;
+  return { clientId, apiKey, fileName, uxMode, redirectUri };
 }
 
 function loadGoogleApiScript() {
@@ -1764,6 +1823,13 @@ function useDriveSync({
     };
   }, []);
 
+  useEffect(() => {
+    if (!config) return;
+    if (config.uxMode === "redirect") {
+      cleanupGoogleOAuthRedirectArtifacts();
+    }
+  }, [config]);
+
   const setDriveState = useCallback(
     (updater) => {
       if (!isMountedRef.current) return;
@@ -2042,7 +2108,11 @@ function useDriveSync({
           resolve(tokenResponse.access_token);
         };
         try {
-          tokenClient.requestAccessToken({ prompt });
+          const requestOptions = { prompt };
+          if (config?.uxMode !== "redirect") {
+            requestOptions.use_fedcm_for_prompt = true;
+          }
+          tokenClient.requestAccessToken(requestOptions);
         } catch (error) {
           if (!silent && error?.message) {
             console.error("Google Identity request failed", error);
@@ -2050,7 +2120,7 @@ function useDriveSync({
           reject(error);
         }
       }),
-    [],
+    [config?.uxMode],
   );
 
   const syncNow = useCallback(
@@ -2159,11 +2229,18 @@ function useDriveSync({
         if (!googleIdentity) {
           throw new Error("Google Identity Services unavailable");
         }
-        tokenClientRef.current = googleIdentity.initTokenClient({
+        const tokenClientOptions = {
           client_id: config.clientId,
           scope: DRIVE_SCOPE,
           callback: () => {},
-        });
+        };
+        if (config.uxMode) {
+          tokenClientOptions.ux_mode = config.uxMode;
+        }
+        if (config.uxMode === "redirect" && config.redirectUri) {
+          tokenClientOptions.redirect_uri = config.redirectUri;
+        }
+        tokenClientRef.current = googleIdentity.initTokenClient(tokenClientOptions);
         setDriveState((prev) => ({ ...prev, status: "ready", error: null }));
         try {
           await requestAccessToken({ prompt: "none", silent: true });


### PR DESCRIPTION
## Summary
- detect when the app runs in a cross-origin isolated context and default Google OAuth to redirect mode
- configure the Google Identity token client with redirect support and scrub redirect artifacts from the URL
- request access tokens with FedCM when available to avoid popup failures in restrictive environments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d68fa6771c83309f1f5d44e926841d