### PR TITLE
Handle Drive discovery fallback errors

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -385,6 +385,22 @@ function loadGoogleIdentityScript() {
   return window.__googleIdentityScriptPromise;
 }
 
+function isDriveDiscoveryDocError(error) {
+  if (!error) return false;
+  const normalized = extractGoogleApiErrorDetails(error);
+  const message = String(normalized?.message || error?.message || "").toLowerCase();
+  if (!message && !normalized) return false;
+  if (message.includes("api discovery response missing required fields")) {
+    return true;
+  }
+  const status = normalized?.status ?? error?.status ?? null;
+  const code = normalized?.code ?? error?.code ?? null;
+  if (Number(status) === 502 || Number(code) === 502) {
+    return true;
+  }
+  return false;
+}
+
 async function initGoogleClient(config) {
   const [gapi] = await Promise.all([loadGoogleApiScript(), loadGoogleIdentityScript()]);
   if (!gapi) throw new Error("Google API unavailable");
@@ -397,7 +413,17 @@ async function initGoogleClient(config) {
         });
         resolve();
       } catch (error) {
-        reject(error);
+        if (!isDriveDiscoveryDocError(error)) {
+          reject(error);
+          return;
+        }
+        try {
+          await gapi.client.init({ apiKey: config.apiKey });
+          await gapi.client.load("drive", "v3", undefined, "https://www.googleapis.com/");
+          resolve();
+        } catch (fallbackError) {
+          reject(fallbackError);
+        }
       }
     });
   });


### PR DESCRIPTION
## Summary
- add detection for Google Drive discovery document failures during client init
- fall back to loading the Drive API from www.googleapis.com when the discovery doc response is invalid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6966012b883309f4800b093892d33