### PR TITLE
Improve Drive discovery error messaging

### DIFF
--- a/app.js
+++ b/app.js
@@ -239,7 +239,7 @@ function maybeWrapDriveInitError(error) {
     friendly.details = details;
     return friendly;
   };
-  if (Number.isFinite(code) && code === 502) {
+  if (lowerMessage.includes("api discovery response missing required fields") || Number.isFinite(code) && code === 502) {
     const wildcardSuggestion = typeof window !== "undefined" && window.location ? `${window.location.origin}/*` : "your site";
     return buildWrappedError(`Google returned HTTP 502 while loading the Drive discovery document. This almost always means the API key's HTTP referrer restrictions don't cover ${currentLocation} or the change hasn't fully propagated. Update the restriction to include this URL (for example, ${wildcardSuggestion}) or temporarily remove it, then try again.`, "drive_discovery_referrer_mismatch");
   }

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -227,7 +227,10 @@ function maybeWrapDriveInitError(error) {
     return friendly;
   };
 
-  if (Number.isFinite(code) && code === 502) {
+  if (
+    lowerMessage.includes("api discovery response missing required fields") ||
+    (Number.isFinite(code) && code === 502)
+  ) {
     const wildcardSuggestion =
       typeof window !== "undefined" && window.location ? `${window.location.origin}/*` : "your site";
     return buildWrappedError(


### PR DESCRIPTION
## Summary
- treat the "API discovery response missing required fields" failure as a Drive discovery 502
- surface the same actionable referrer guidance when Google returns that error string

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d69eb33b908330bc0d98efe0be8879